### PR TITLE
veda #115: fix to apply discount if no priceset enabled in discount code configuration

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -369,8 +369,8 @@ function cividiscount_civicrm_buildAmount($pagetype, &$form, &$amounts) {
       }
       $priceFields = isset($discount['pricesets']) ? $discount['pricesets'] : array();
       if (empty($priceFields) && !empty($code)) {
-        // apply discount to all the price fields for quickconfig pricesets
-        if ($pagetype == 'event' && $isQuickConfigPriceSet) {
+        // apply discount to all the price fields if no price set set
+        if ($pagetype == 'event') {
           $applyToAllLineItems = TRUE;
           if (!empty($key)) {
             $discounts[$key]['pricesets'] = array_keys($priceSetInfo);


### PR DESCRIPTION
1. At the moment, if no price option is chosen for a price set, when you configure discount code, then discounts don't apply to price-set and however, discount is happening for quick config price set

This has been fixed

dlobo#92
