### PR TITLE
Veda #313: break loop if no code is available when discounted page loads to display discount code text box

### DIFF
--- a/CRM/CiviDiscount/DiscountCalculator.php
+++ b/CRM/CiviDiscount/DiscountCalculator.php
@@ -180,6 +180,12 @@ class CRM_CiviDiscount_DiscountCalculator {
       }
       if ($this->checkDiscountsByEntity($discount, $this->entity, $this->entity_id, 'filters')) {
         $this->entity_discounts[$discount_id] = $discount;
+        /* Added by BOT
+        * To decide if discount text box should be displayed, no need to loop through all discount codes 
+        */ 
+        if( empty( $this->code ) ) {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
issue: It takes so much time when a page, set up with discount, loads if there are so many discount codes

fixes:
1. This code was done by Anum Goel agoel@backofficethinking.com, pls look at veda ticket

2.Tested with lots of discounted code (more than 1000s), efficiency improved on discount page loads
