### PR TITLE
Payment type discount alert text removed & disable inputs while loading

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -263,15 +263,13 @@ function cividiscount_civicrm_validateForm($name, &$fields, &$files, &$form, &$e
 function validate_email_for_discount($form){
     $new_member = TRUE;
 
-    $submitted_email = $form->_submitValues['email-5'];
-
-    if (!isset($submitted_email)) {
+    if (!isset($form->_submitValues['email-5'])) {
       return $new_member;
     }
     
     $result = civicrm_api3('Email', 'get', array(
       'return' => "contact_id",
-      'email' => $submitted_email,
+      'email' => $form->_submitValues['email-5'],
       'is_primary' => 1,
     ));
     $id = $result['id'];
@@ -406,7 +404,6 @@ function cividiscount_civicrm_buildAmount($pagetype, &$form, &$amounts) {
 
     if (!empty($payids) && !empty($code)) {
       if (!in_array($selectedProcessorValue, $payids)) {
-        echo "Sorry! This payment type does not provide discount!";
         return;
       }
     }

--- a/templates/CRM/Contribute/Form/Contribution/Main.extra.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.extra.tpl
@@ -22,7 +22,8 @@ CRM.$(function($) {
 </script>
 
 {/literal}
-
-<div id="loading" style="position: fixed; top: 50%; left:40%; background: #000; opacity:0.5; text-align: center; width:20%; line-height: 2.5; border-radius:10px; font-size:20px; font-size: 1.6vw; color:#fff;">
+<div id="loading" style="position: fixed; top: 0; bottom: 0; left: 0; right: 0;">
+  <div style="position: fixed; top: 50%; left:40%; background: #000; opacity:0.5; text-align: center; width:20%; line-height: 2.5; border-radius:10px; font-size:20px; font-size: 1.6vw; color:#fff;">
     Loading... Please wait...
+  </div>  
 </div>


### PR DESCRIPTION
The text at top of form "Sorry! this payment type does not provide discount!" removed. 
Form fields are now uneditable while page loading.  Fixed error caused by assigning $submitted_email before it is entered by the user.
